### PR TITLE
Upgrade dependencies and add newtype + refined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ boot/
 lib_managed/
 src_managed/
 project/plugins/project/
+.metals

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -3,16 +3,21 @@ ThisBuild / organization := "$organization$"
 ThisBuild / scalaVersion := "$scalaVersion$"
 
 val DeclineVersion       = "$declineVersion$"
+val NewtypeVersion       = "$newtypeVersion"
 val RasterFoundryVersion = "$rfVersion$"
+val RefinedVersion       = "$refinedVersion"
 val SttpVersion          = "$sttpVersion$"
 
 val cliDependencies = List(
   "com.monovore"                 %% "decline"                        % DeclineVersion,
   "com.monovore"                 %% "decline-effect"                 % DeclineVersion,
+  "com.monovore"                 %% "decline-refined"                % DeclineVersion,
   "com.rasterfoundry"            %% "datamodel"                      % RasterFoundryVersion,
   "com.softwaremill.sttp.client" %% "async-http-client-backend-cats" % SttpVersion,
   "com.softwaremill.sttp.client" %% "circe"                          % SttpVersion,
-  "com.softwaremill.sttp.client" %% "core"                           % SttpVersion
+  "com.softwaremill.sttp.client" %% "core"                           % SttpVersion,
+  "eu.timepit"                   %% "refined"                        % RefinedVersion,
+  "io.estatico"                  %% "newtype"                        % NewtypeVersion
 )
 
 lazy val cli = (project in file("./cli"))

--- a/src/main/g8/cli/src/main/scala/package.scala
+++ b/src/main/g8/cli/src/main/scala/package.scala
@@ -1,0 +1,8 @@
+package $organization$
+
+import io.estatico.newtype.Coercible
+import com.monovore.decline.Argument
+
+package object $name$ {
+  implicit def coercibleArg[R, N](implicit ev: Coercible[Argument[R], Argument[N]], R: Argument[R]) = ev(R)
+}

--- a/src/main/g8/cli/src/main/scala/package.scala
+++ b/src/main/g8/cli/src/main/scala/package.scala
@@ -3,6 +3,6 @@ package $organization$
 import io.estatico.newtype.Coercible
 import com.monovore.decline.Argument
 
-package object $name$ {
+package object $name;format="norm,word"$ {
   implicit def coercibleArg[R, N](implicit ev: Coercible[Argument[R], Argument[N]], R: Argument[R]) = ev(R)
 }

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,7 +3,9 @@ name = My Something Project
 package = $organization$.$name;format="norm,word"$
 description = Say something about this template.
 cliName = good-cli-name
-rfVersion = 1.40.3
-scalaVersion = 2.12.11
-declineVersion = 1.0.0
-sttpVersion = 2.0.7
+rfVersion = 1.45.0
+scalaVersion = 2.12.12
+declineVersion = 1.2.0
+newtypeVersion = 0.4.4
+refinedVersion = 0.9.14
+sttpVersion = 2.1.1


### PR DESCRIPTION
Overview
-----

This PR adds newtype and refined as dependencies and adds an implicit to get `Argument` evidence for anything coercible to
something that already has `Argument` evidence. Essentially, it backports https://github.com/azavea/sentinel-2-stac-utils/pull/6

Testing
-----

- create a new repo using this template
- make a newtype and demand it as an argument -- I did that by making the top of my `Commands.scala` look like this (my `name` g8 parameter was "foo bar baz"):

```
package com.azavea.foobarbaz

import cats.implicits._
import com.monovore.decline._
import eu.timepit.refined.types.string.NonEmptyString
import io.estatico.newtype.macros.newtype

object Commands {

  @newtype case class Foo(value: NonEmptyString)

  private val fooOpt: Opts[Foo] = Opts.option[Foo]("foo", help = "FOO")

```

- it should compile